### PR TITLE
Fix stoplights moving when marquee is on

### DIFF
--- a/index.less
+++ b/index.less
@@ -470,6 +470,8 @@ body {
             margin-bottom: 0px;
             margin-top: 0px;
             border-radius: 5px;
+            position: absolute;
+            left: 0px;
 
             .mediaitem-artwork {
                 border-radius: 5px;
@@ -522,6 +524,13 @@ body {
 
         .audio-type {
             margin-right: 10px;
+        }
+
+        .playback-info{
+            position: absolute;
+            height: 100%;
+            left: 50px;
+            width: calc(100% - 50px);
         }
     }
 


### PR DESCRIPTION
Set the playback-info as absolute instead to lock the that view, therefore preventing the view to affect the already hacky stoplights